### PR TITLE
Proposed changes to stochastic mult update algorithm

### DIFF
--- a/cmfpy/algs/base.py
+++ b/cmfpy/algs/base.py
@@ -13,7 +13,7 @@ class AbstractOptimizer:
     """Defines common API for optimizer objects."""
 
     def __init__(self, data, model_dimensions, initW=None, initH=None,
-                 tol=1e-5, patience=3, **kwargs):
+                 tol=1e-5, patience=3):
         """Initialize algorithm."""
 
         # Check inputs,

--- a/cmfpy/algs/mult.py
+++ b/cmfpy/algs/mult.py
@@ -11,50 +11,22 @@ class MultUpdate(AbstractOptimizer):
     """
     Multiplicative update rule.
     """
-    def __init__(self, data, dims, patience=3, tol=1e-5, **kwargs):
-        super().__init__(data, dims, patience=patience, tol=tol, **kwargs)
-        self.stochastic = kwargs.get('stochastic', False)
-        if self.stochastic:
-            if not 'window_size' in kwargs:
-                raise AttributeError("Must pass keyword argument window_size to use stochastic updates")
-            self.window_size = kwargs['window_size']
+    def __init__(self, data, dims, patience=3, tol=1e-5):
+        super().__init__(data, dims, patience=patience, tol=tol)
 
     def update(self):
-        if self.stochastic:
-            X = self.X
-            H = self.H
-            W = self.W
-            window_size = self.window_size
+        # update W
+        num_W, denom_W = self._compute_mult_W()
+        self.W = np.divide(np.multiply(self.W, num_W), denom_W + EPSILON)
 
-            (_, T) = X.shape
-            start_idx = np.random.randint(T - window_size + 1)
-            X = X[:, start_idx:start_idx + window_size]
-            H = H[:, start_idx:start_idx + window_size]
-
-            num_W, denom_W = self._compute_mult_W(X, W, H)
-
-            # The stochastic W update is unchanged – we still update every entry
-            self.W = np.divide(np.multiply(self.W, num_W), denom_W + EPSILON)
-
-            num_H, denom_H = self._compute_mult_H(X, W, H)
-
-            # For the stochastic H update we only update a subset of entries
-            H_new = np.divide(np.multiply(H, num_H), denom_H + EPSILON)
-            self.H[:, start_idx:start_idx + window_size] = H_new
-
-        else:
-            # update W
-            num_W, denom_W = self._compute_mult_W()
-            self.W = np.divide(np.multiply(self.W, num_W), denom_W + EPSILON)
-
-            # update H
-            num_H, denom_H = self._compute_mult_H()
-            self.H = np.divide(np.multiply(self.H, num_H), denom_H + EPSILON)
+        # update H
+        num_H, denom_H = self._compute_mult_H()
+        self.H = np.divide(np.multiply(self.H, num_H), denom_H + EPSILON)
 
         self.cache_resids()
         return self.loss
 
-    def _compute_mult_W(self, X = None, W = None, H = None):
+    def _compute_mult_W(self, X=None, W=None, H=None):
         X = X if X is not None else self.X
         W = W if W is not None else self.W
         H = H if H is not None else self.H
@@ -73,7 +45,7 @@ class MultUpdate(AbstractOptimizer):
 
         return num, denom
 
-    def _compute_mult_H(self, X = None, W = None, H = None):
+    def _compute_mult_H(self, X=None, W=None, H=None):
         X = X if X is not None else self.X
         W = W if W is not None else self.W
         H = H if H is not None else self.H
@@ -84,3 +56,39 @@ class MultUpdate(AbstractOptimizer):
         denom = tensor_transconv(W, est)
 
         return num, denom
+
+
+class StochasticMultUpdate(MultUpdate):
+    def __init__(self, data, dims, patience=3, tol=1e-5, window_size=5000):
+        """Initialize Stochastic Update Rule."""
+
+        # Invoke super constructor, but additionally stores data window size.
+        super().__init__(data, dims, patience=patience, tol=tol)
+        self.window_size = window_size
+
+    def update(self):
+        """
+        Overrides update rule to work on portions of the data matrix.
+        """
+
+        # Pick random window of data
+        start_idx = np.random.randint(self.n_timepoints - self.window_size + 1)
+        t_idx = range(start_idx, start_idx + window_size)
+
+        # Select time window.
+        X = self.X[:, t_idx]
+        H = self.H[:, t_idx]
+
+        # The stochastic W update is unchanged – we still update every entry
+        num_W, denom_W = self._compute_mult_W(X, self.W, H)
+        self.W = (self.W * num_W) / (denom_W + EPSILON)
+
+        # For the stochastic H update we only update a subset of entries
+        num_H, denom_H = self._compute_mult_H(X, self.W, H)
+        self.H[:, t_idx] = (H * num_H) / (denom_H + EPSILON)
+
+        # TODO: cache_resids needs to be changed so that it's limited to the
+        # time window (t_idx)!!! Otherwise this step is going to be unfeasibly
+        # expensive...
+        self.cache_resids()
+        return self.loss


### PR DESCRIPTION
Here is a prototype for implementing the stochastic multiplicative update as a separate class. I think this is cleaner, but let's discuss if you disagree!

Perhaps the nicest thing is that you don't need the big `if` statement in `self.update(...)`, instead you have the child class override that function. This also means that you don't need to add the `stochastic=True` / `stochastic=False` keyword, solving the problem you briefly mentioned in #23

You'll see there is one problem left, which is that we probably want to modify `cache_resids()` so that it doesn't recompute the loss for the entire dataset, but instead only does so for the window of data.